### PR TITLE
18f.github.io is deprecated

### DIFF
--- a/pages/18f-list.md
+++ b/pages/18f-list.md
@@ -11,9 +11,9 @@ This list is part of the [/Developer Program](https://pages.18f.gov/API-All-the-
 
 [CSV](http://18f.github.io/API-All-the-X/data/individual_apis.csv) - [JSON](http://18f.github.io/API-All-the-X/data/individual_apis.json) - [XML](http://18f.github.io/API-All-the-X/data/individual_apis.xml) - [YML](https://raw.githubusercontent.com/18F/API-All-the-X/gh-pages/_data/individual_apis.yml) - *[[Edit](https://github.com/18F/API-All-the-X/edit/gh-pages/_data/individual_apis.yml)]*
 
-Note: Iframe (below) is breaking b/c it's across the domain, [but it can be seen as HTML here](http://pages.18f.gov/API-All-the-X/data/individual_apis).  
+Note: Iframe (below) is breaking b/c it's across the domain, [but it can be seen as HTML here](https://pages.18f.gov/API-All-the-X/data/individual_apis).  
 
-<iframe src="http://18f.github.io/API-All-the-X/data/individual_apis" frameborder="0" width="800" height="800"></iframe>
+<iframe src="https://pages.18f.gov/API-All-the-X/data/individual_apis" frameborder="0" width="800" height="800"></iframe>
 
 
 

--- a/pages/18f-list.md
+++ b/pages/18f-list.md
@@ -11,7 +11,7 @@ This list is part of the [/Developer Program](https://pages.18f.gov/API-All-the-
 
 [CSV](http://18f.github.io/API-All-the-X/data/individual_apis.csv) - [JSON](http://18f.github.io/API-All-the-X/data/individual_apis.json) - [XML](http://18f.github.io/API-All-the-X/data/individual_apis.xml) - [YML](https://raw.githubusercontent.com/18F/API-All-the-X/gh-pages/_data/individual_apis.yml) - *[[Edit](https://github.com/18F/API-All-the-X/edit/gh-pages/_data/individual_apis.yml)]*
 
-Note: Iframe (below) is breaking b/c it's across the domain, [but it can be seen as HTML here](http://18f.github.io/API-All-the-X/data/individual_apis).  
+Note: Iframe (below) is breaking b/c it's across the domain, [but it can be seen as HTML here](http://pages.18f.gov/API-All-the-X/data/individual_apis).  
 
 <iframe src="http://18f.github.io/API-All-the-X/data/individual_apis" frameborder="0" width="800" height="800"></iframe>
 


### PR DESCRIPTION
This URL needs to be pointed at pages.18f.gov, not 18f.github.io. That page does not resolve yet on pages.18f.gov but could be resolved by a pull request from the `gh-pages` branch to the `18f-pages` branch.
