### PR TITLE
Add APIs.guru to list of other lists

### DIFF
--- a/pages/other-lists.md
+++ b/pages/other-lists.md
@@ -13,6 +13,7 @@ These are partial lists of US government APIs.
   * [APIs.io API, filted for a search query of .gov](http://apis.io/api/search?q=.gov&limit=1000)
 * [PublicAPIs.com](https://www.publicapis.com/search?keyword=federal)
 * [FedAPI.io](https://fedapi.io/www/)
+* [APIs.guru](https://github.com/APIs-guru/api-models)
 * _[What others exist?](https://github.com/unitedstates/APIs/issues/8)_  
 
 ### Notes 


### PR DESCRIPTION
In [my collection](https://github.com/APIs-guru/api-models) I have some government APIs.
At the moment I don't have tags system in place so I just list them:
https://github.com/APIs-guru/api-models/blob/master/APIs/consumerfinance.gov
https://github.com/APIs-guru/api-models/tree/master/APIs/data.gov
https://github.com/APIs-guru/api-models/tree/master/APIs/gsa.gov
https://github.com/APIs-guru/api-models/blob/master/APIs/healthcare.gov
https://github.com/APIs-guru/api-models/blob/master/APIs/hhs.gov
https://github.com/APIs-guru/api-models/tree/master/APIs/nrel.gov
https://github.com/APIs-guru/api-models/tree/master/APIs/nsidc.org

P.S. I'm really interested in collaboration.
I believe that API definitions should be used by "smart clients", right now it's only [fifth of them](https://github.com/APIs-guru/api-models#existing-integrations) but this list is growing.
